### PR TITLE
Add flit.ini for PyPI release

### DIFF
--- a/chorogrid/__init__.py
+++ b/chorogrid/__init__.py
@@ -3,6 +3,10 @@
 
 # Author: David Taylor (@Prooffreader)
 
+"""A python script to produce choropleths and colored square- and hex-grid maps"""
+
+__version__ = '0.0.1'
+
 from chorogrid.Colorbin import Colorbin
 from chorogrid.Chorogrid import Chorogrid
 

--- a/flit.ini
+++ b/flit.ini
@@ -1,0 +1,8 @@
+[metadata]
+module = chorogrid
+author = David Taylor
+author-email = prooffreader@gmail.com
+home-page = https://github.com/Prooffreader/chorogrid
+classifiers = License :: OSI Approved :: MIT License
+description-file = README.md
+requires = pandas


### PR DESCRIPTION
Hi,

I wanted to use your package in a lecture and it was a bit inconvenient that your package wasn't `pip install`able, so I uploaded it to PyPI via [`flit`](http://flit.readthedocs.io/en/latest/index.html). If you're planning on making any more changes at any point, let me know your PyPI account name and I'll transfer it over to you.

Best,
Brett

(fixes #8)